### PR TITLE
fix vercel deployment API routing

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,23 +1,9 @@
 {
   "version": 2,
   "builds": [
-    {
-      "src": "index.html",
-      "use": "@vercel/static"
-    },
-    {
-      "src": "app.js",
-      "use": "@vercel/static"
-    },
-    {
-      "src": "styles.css",
-      "use": "@vercel/static"
-    }
-  ],
-  "routes": [
-    {
-      "src": "/(.*)",
-      "dest": "/$1"
-    }
+    { "src": "index.html", "use": "@vercel/static" },
+    { "src": "app.js", "use": "@vercel/static" },
+    { "src": "styles.css", "use": "@vercel/static" },
+    { "src": "api/**/*.js", "use": "@vercel/node" }
   ]
 }


### PR DESCRIPTION
## Summary
- configure Vercel to build API functions
- remove route rewrite that masked `/api` endpoints

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a4a9a8496883269285f3cf1af33595