### PR TITLE
Configure API routes for Vercel deployment

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -5,5 +5,9 @@
     { "src": "app.js", "use": "@vercel/static" },
     { "src": "styles.css", "use": "@vercel/static" },
     { "src": "api/**/*.js", "use": "@vercel/node" }
+  ],
+  "routes": [
+    { "src": "/api/(.*)", "dest": "/api/$1" },
+    { "src": "/(.*)", "dest": "/$1" }
   ]
 }


### PR DESCRIPTION
## Summary
- Add Vercel routes to pass `/api` requests directly to serverless functions.
- Ensure API directory is built with `@vercel/node`.

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx vercel dev` *(fails: requires login in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ac24ed64832689cec675e8869386