### PR TITLE
Configure API routes for Vercel deployment

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -5,5 +5,10 @@
     { "src": "app.js", "use": "@vercel/static" },
     { "src": "styles.css", "use": "@vercel/static" },
     { "src": "api/**/*.js", "use": "@vercel/node" }
+  ],
+  "routes": [
+    { "src": "/api/lists", "dest": "/api/lists.js" },
+    { "src": "/api/lists/(.*)/fields", "dest": "/api/lists/[id]/fields.js" },
+    { "src": "/(.*)", "dest": "/$1" }
   ]
 }


### PR DESCRIPTION
## Summary
- Add Vercel routes that explicitly map `/api/lists` and `/api/lists/[id]/fields` to their serverless function files
- Ensure static assets and remaining paths are served without interfering with API requests

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx vercel dev` *(fails: requires interactive login)*

------
https://chatgpt.com/codex/tasks/task_e_68a4ac24ed64832689cec675e8869386