### PR TITLE
Make funnel visualization responsive

### DIFF
--- a/public/app.js
+++ b/public/app.js
@@ -767,19 +767,19 @@ function createFunnelVisualization() {
             'url(#gradient10)'
         ];
         
-        // Create SVG for funnel - Made bigger with extra space for arrows
-        const width = 900;
+        // Create SVG for funnel - Made responsive with container width
+        const width = container.clientWidth;
         const margin = { top: 30, right: 120, bottom: 30, left: 30 }; // Extra right margin for arrows
         const stageHeight = 80;
         const spacing = 15;
         const totalHeight = stageData.length * (stageHeight + spacing) + margin.top + margin.bottom;
         const height = Math.max(600, totalHeight);
-        
+
         const svg = d3.select(container)
             .append('svg')
-            .attr('width', width)
-            .attr('height', height)
-            .style('max-width', '100%')
+            .attr('viewBox', `0 0 ${width} ${height}`)
+            .attr('preserveAspectRatio', 'xMinYMin meet')
+            .style('width', '100%')
             .style('height', 'auto');
         
         // Add gradient definitions

--- a/public/styles.css
+++ b/public/styles.css
@@ -500,11 +500,16 @@ body {
 
 /* Funnel Visualization */
 .funnel-viz {
-    min-height: 600px;
     position: relative;
     display: flex;
     justify-content: center;
     align-items: center;
+}
+
+@media (max-width: 600px) {
+    .funnel-viz {
+        min-height: 400px;
+    }
 }
 
 .funnel-viz svg {
@@ -514,7 +519,6 @@ body {
 
 /* Make funnel visualization bigger */
 #funnelViz {
-    min-height: 600px;
     display: flex;
     justify-content: center;
     align-items: center;


### PR DESCRIPTION
## Summary
- use container width and viewBox for funnel SVG to adapt sizing
- remove hard min-height from funnel styles and add mobile-friendly sizing

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a4e559313483268c0d794758707c28