### PR TITLE
Improve summary stats responsiveness

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -1908,7 +1908,7 @@ body {
 /* Improved Summary Stats - Juvo Blue Theme */
 .summary-stats {
     display: grid;
-    grid-template-columns: repeat(4, 1fr);
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
     gap: 20px;
     margin-bottom: 30px;
     justify-content: center;
@@ -2258,14 +2258,12 @@ body {
 /* Responsive adjustments */
 @media (max-width: 1200px) {
     .summary-stats {
-        grid-template-columns: repeat(2, 1fr);
         gap: 15px;
     }
 }
 
 @media (max-width: 768px) {
     .summary-stats {
-        grid-template-columns: 1fr;
         gap: 15px;
     }
     
@@ -2287,4 +2285,10 @@ body {
         padding: 8px 12px;
         font-size: 12px;
     }
-} 
+}
+
+@media (max-width: 480px) {
+    .summary-stats {
+        gap: 10px;
+    }
+}


### PR DESCRIPTION
## Summary
- adapt summary stats grid to use auto-fit with minmax to improve responsiveness
- refine responsive breakpoints, dropping fixed column counts and adding extra-small gap rule

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a4e55a41288326ba325bf4dc0d0013