### PR TITLE
Reduce chart height on small screens

### DIFF
--- a/public/styles.css
+++ b/public/styles.css
@@ -2287,4 +2287,9 @@ body {
         padding: 8px 12px;
         font-size: 12px;
     }
-} 
+}
+
+@media (max-width:768px){
+    .funnel-viz{ min-height:400px; }
+    .pipeline-viz{ min-height:400px; }
+}


### PR DESCRIPTION
## Summary
- decrease min-height to 400px for funnel and pipeline visualizations on screens <=768px to improve mobile rendering

## Testing
- `npm test` *(fails: Missing script: "test")*
- `python -m http.server 8000 --directory public` *(served index; verified charts render with new height)*

------
https://chatgpt.com/codex/tasks/task_e_68a4e55b49688326bef7c9b044941c1e